### PR TITLE
Fix use of duplicate variable name conflicting with a parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Usage example
 -------------
 
 ```
+CREATE EXTENSION pg_show_rewritten_query;
+
 SELECT * FROM pg_show_rewritten_query('select * from pg_stat_bgwriter');
                                pg_show_rewritten_query
 --------------------------------------------------------------------------------------

--- a/pg_show_rewritten_query.c
+++ b/pg_show_rewritten_query.c
@@ -83,18 +83,16 @@ pg_show_rewritten_query(PG_FUNCTION_ARGS)
 
 	foreach(lc, querytree_list)
 	{
-		char *sql;
-
 		query = (Query *) lfirst(lc);
 
 		if (query->utilityStmt)
 			appendStringInfo(&res, "%s;\n", sql);
 		else
 		{
-			sql = pg_get_querydef(query, pretty);
+			char *lsql = pg_get_querydef(query, pretty);
 
-			appendStringInfo(&res, "%s;\n", sql);
-			pfree(sql);
+			appendStringInfo(&res, "%s;\n", lsql);
+			pfree(lsql);
 		}
 	}
 	PG_RETURN_TEXT_P(cstring_to_text(res.data));


### PR DESCRIPTION
Also add a create extension statement to the example in the documentation.